### PR TITLE
minor - added some bottom padding to the navbar when it collapses below the logo

### DIFF
--- a/www/js/nav-handler.js
+++ b/www/js/nav-handler.js
@@ -17,9 +17,11 @@ $(function () {
 		if (bodyWidth <= oceanLogoWidth + navbar.width() + 15) {
 			navbar.css('display', 'block');  // allow to spill onto next line
 			navbar.width(navbarInitialWidth);  // to make sure navbar width can be accurately computed
+			navbar.css('padding-bottom', '5px');
 		} else {
 			navbar.css('display', 'inline-block');  // pull the navbar back up next to the logo
 			navbar.css('margin-left', (navbarMargin + "px"));  // add the margin
+			navbar.css('padding-bottom', 'none');
 		}
 	}
 


### PR DESCRIPTION
On the index page, when the navbar collapses below the logo because of the page width being too small, it now has some padding separating it from the lower border, to improve readability.
